### PR TITLE
fix!: correct misspelling of a word sign

### DIFF
--- a/Api/Controllers/AccountController.cs
+++ b/Api/Controllers/AccountController.cs
@@ -1,6 +1,6 @@
 using Application.WorkAccount.Commands.RegisterUser;
 using Application.WorkAccount.Commands.ResetPassword;
-using Application.WorkAccount.Commands.SingUpUser;
+using Application.WorkAccount.Commands.SignUpUser;
 using Application.WorkAccount.Queries.ConfirmAccount;
 using Application.WorkAccount.Queries.ForgotPassword;
 using Application.WorkAccount.Queries.GenerateTokenToResetPassword;
@@ -41,10 +41,10 @@ public class AccountController : ApiController
     /// <param name="request"></param>
     /// <param name="who"></param>
     /// <returns></returns>
-    [HttpPost("sing-in/{who}")]
-    public async Task<IActionResult> SingIn([FromBody] SingInUserRequest request, [FromRoute]UserRoles who)
+    [HttpPost("sign-in/{who}")]
+    public async Task<IActionResult> SignIn([FromBody] SignInUserRequest request, [FromRoute]UserRoles who)
     {
-        var command = new SingInUserCommand(
+        var command = new SignInUserCommand(
             request.Login,
             request.Password,
             who);

--- a/Application/WorkAccount/Commands/SignInUser/SignInUserCommand.cs
+++ b/Application/WorkAccount/Commands/SignInUser/SignInUserCommand.cs
@@ -3,9 +3,9 @@ using Core.Account.enums;
 using MediatR;
 using ErrorOr;
 
-namespace Application.WorkAccount.Commands.SingUpUser;
+namespace Application.WorkAccount.Commands.SignUpUser;
 
-public record SingInUserCommand(
+public record SignInUserCommand(
     string Login,
     string Password,
     UserRoles Who

--- a/Application/WorkAccount/Commands/SignInUser/SignInUserHandler.cs
+++ b/Application/WorkAccount/Commands/SignInUser/SignInUserHandler.cs
@@ -4,18 +4,18 @@
     using MediatR;
     using ErrorOr;
 
-    namespace Application.WorkAccount.Commands.SingUpUser;
+    namespace Application.WorkAccount.Commands.SignUpUser;
 
-    public class SingInUserHandler : IRequestHandler<SingInUserCommand, ErrorOr<AccountResponse>>
+    public class SignInUserHandler : IRequestHandler<SignInUserCommand, ErrorOr<AccountResponse>>
     {
         private readonly IAccountRepository _accountRepository;
 
-        public SingInUserHandler(IAccountRepository accountRepository)
+        public SignInUserHandler(IAccountRepository accountRepository)
         {
             _accountRepository = accountRepository;
         }
         
-        public async Task<ErrorOr<AccountResponse>> Handle(SingInUserCommand request, CancellationToken cancellationToken)
+        public async Task<ErrorOr<AccountResponse>> Handle(SignInUserCommand request, CancellationToken cancellationToken)
         {
             var user = await _accountRepository.UserData(request.Login,request.Password ,request.Who, cancellationToken);
 

--- a/Application/WorkAccount/Commands/SignInUser/SignInUserRequest.cs
+++ b/Application/WorkAccount/Commands/SignInUser/SignInUserRequest.cs
@@ -1,0 +1,5 @@
+namespace Application.WorkAccount.Commands.SignUpUser;
+
+public record SignInUserRequest(
+    string Login,
+    string Password);

--- a/Application/WorkAccount/Commands/SignInUser/SignInUserValidator.cs
+++ b/Application/WorkAccount/Commands/SignInUser/SignInUserValidator.cs
@@ -1,10 +1,10 @@
 using FluentValidation;
 
-namespace Application.WorkAccount.Commands.SingUpUser;
+namespace Application.WorkAccount.Commands.SignUpUser;
 
-public class SingInUserValidator : AbstractValidator<SingInUserCommand>
+public class SignInUserValidator : AbstractValidator<SignInUserCommand>
 {
-    public SingInUserValidator()
+    public SignInUserValidator()
     {
         RuleFor(x => x.Login)
             .NotEmpty().WithMessage("Podaj poprawny e-mail!");

--- a/Application/WorkAccount/Commands/SingInUser/SingInUserRequest.cs
+++ b/Application/WorkAccount/Commands/SingInUser/SingInUserRequest.cs
@@ -1,5 +1,0 @@
-namespace Application.WorkAccount.Commands.SingUpUser;
-
-public record SingInUserRequest(
-    string Login,
-    string Password);


### PR DESCRIPTION
This pull request corrects a misspelling of a word *sign*. This is a breaking change, because the endpoint path changes from `/account/sing-in` to `/account/sign-in`.

Please make sure that I have not made any mistakes, as I am unable to test the code myself.